### PR TITLE
Jointests

### DIFF
--- a/src/tech/ml/dataset.clj
+++ b/src/tech/ml/dataset.clj
@@ -71,7 +71,10 @@
                         ->>dataset
                         from-prototype
                         dataset->string
-                        join-by-column)
+                        join-by-column
+                        left-join
+                        right-join
+                        inner-join)
 
 
 (par-util/export-symbols tech.ml.dataset.impl.dataset

--- a/src/tech/ml/dataset/base.clj
+++ b/src/tech/ml/dataset/base.clj
@@ -719,3 +719,17 @@ the correct type."
       (when lhs-missing?
         {:lhs-missing lhs-missing
          :lhs-outer-join (select lhs :all lhs-missing)})))))
+
+(defn inner-join [colname lhs rhs]
+  (-> (join-by-column colname lhs rhs)
+      :join-table))
+
+(defn left-join  [colname lhs rhs]
+  (-> (join-by-column colname lhs rhs {:lhs-missing? true})
+      :lhs-outer-join))
+
+(defn right-join [colname lhs rhs]
+  (-> (join-by-column colname lhs rhs {:rhs-missing? true})
+      :rhs-outer-join))
+
+

--- a/test/tech/ml/dataset/join_test.clj
+++ b/test/tech/ml/dataset/join_test.clj
@@ -77,7 +77,9 @@
   (let [joined   (ds/left-join  "CustomerID" customers orders)
         recs     (ds/mapseq-reader joined)]
     (is (= 2 (count recs)))
-    (is (= #{1 3} (set (map #(get % "CustomerID") recs))))))
+    (is (= #{1 3} (set (map #(get % "CustomerID") recs))))
+    (is (= (set (ds/column-names joined))
+           all-fields))))
 
 (deftest right-join-test
   (let [joined  (ds/right-join "CustomerID" customers orders)

--- a/test/tech/ml/dataset/join_test.clj
+++ b/test/tech/ml/dataset/join_test.clj
@@ -21,49 +21,77 @@
 
 
 ;;sample from https://www.w3schools.com/sql/sql_join_left.asp
-(deftest left-join-test
-  (let [lhs (ds/->dataset [{"CustomerID" 1,
-                            "CustomerName" "Alfreds Futterkiste",
-                            "ContactName" "Maria Anders",
-                            "Address" "Obere Str. 57",
-                            "City" "Berlin",
-                            "PostalCode" 12209,
-                            "Country" "Germany"}
-                           {"CustomerID" 2,
-                            "CustomerName" "Ana Trujillo Emparedados y helados",
-                            "ContactName" "Ana Trujillo",
-                            "Address" "Avda. de la Constitución 2222",
-                            "City" "México D.F.",
-                            "PostalCode" 5021,
+(def customers
+  (ds/->dataset [{"CustomerID" 1,
+                  "CustomerName" "Alfreds Futterkiste",
+                  "ContactName" "Maria Anders",
+                  "Address" "Obere Str. 57",
+                  "City" "Berlin",
+                  "PostalCode" 12209,
+                  "Country" "Germany"}
+                 {"CustomerID" 2,
+                  "CustomerName" "Ana Trujillo Emparedados y helados",
+                  "ContactName" "Ana Trujillo",
+                  "Address" "Avda. de la Constitución 2222",
+                  "City" "México D.F.",
+                  "PostalCode" 5021,
                             "Country" "Mexico"}
-                           {"CustomerID" 3,
+                 {"CustomerID" 3,
                             "CustomerName" "Antonio Moreno Taquería",
-                            "ContactName" "Antonio Moreno",
-                            "Address" "Mataderos 2312",
-                            "City" "México D.F.",
-                            "PostalCode" 5023,
-                            "Country" "Mexico"}])
+                  "ContactName" "Antonio Moreno",
+                  "Address" "Mataderos 2312",
+                  "City" "México D.F.",
+                  "PostalCode" 5023,
+                  "Country" "Mexico"}]))
 
-        rhs (ds/->dataset [{"OrderID" 10308,
-                            "CustomerID" 2,
-                            "EmployeeID" 7,
-                            "OrderDate" "1996-09-18",
-                            "ShipperID" 3}
-                           {"OrderID" 10309,
-                            "CustomerID" 37,
-                            "EmployeeID" 3,
-                            "OrderDate" "1996-09-19",
-                            "ShipperID" 1}
-                           {"OrderID" 10310,
-                            "CustomerID" 77,
-                            "EmployeeID" 8,
-                            "OrderDate" "1996-09-20",
-                            "ShipperID" 2}])
-        joined (:lhs-outer-join
-                (ds/join-by-column "CustomerID" lhs rhs {:lhs-missing? true}))
-        recs   (ds/mapseq-reader joined)]
+(def orders
+  (ds/->dataset [{"OrderID" 10308,
+                  "CustomerID" 2,
+                  "EmployeeID" 7,
+                  "OrderDate" "1996-09-18",
+                  "ShipperID" 3}
+                 {"OrderID" 10309,
+                  "CustomerID" 37,
+                  "EmployeeID" 3,
+                  "OrderDate" "1996-09-19",
+                  "ShipperID" 1}
+                 {"OrderID" 10310,
+                  "CustomerID" 77,
+                  "EmployeeID" 8,
+                  "OrderDate" "1996-09-20",
+                  "ShipperID" 2}]))
+
+
+(def all-fields #{"Address"
+                  "Country"
+                  "OrderID"
+                  "OrderDate"
+                  "ContactName"
+                  "PostalCode"
+                  "CustomerName"
+                  "ShipperID"
+                  "CustomerID"
+                  "EmployeeID"
+                  "City"})
+(deftest left-join-test
+  (let [joined   (ds/left-join  "CustomerID" customers orders)
+        recs     (ds/mapseq-reader joined)]
     (is (= 2 (count recs)))
     (is (= #{1 3} (set (map #(get % "CustomerID") recs))))))
+
+(deftest right-join-test
+  (let [joined  (ds/right-join "CustomerID" customers orders)
+        recs    (ds/mapseq-reader joined)]
+    (is (= 2 (count recs)))
+    (is (= (set (ds/column-names joined))
+           all-fields))))
+
+(deftest inner-join-test
+  (let [joined  (ds/inner-join "CustomerID" customers orders)
+        recs    (ds/mapseq-reader joined)]
+    (is (= 1 (count recs)))
+    (is (= (set (ds/column-names joined))
+           all-fields))))
 
 
 (comment


### PR DESCRIPTION
Possible wrapper for common joins in tech.ml.dataset, which provide functions of the type:
column -> dataset -> dataset -> dataset, rather than the lower level map of {:keys [join-table lhs-missing rhs-missing lhs-outer-join rhs-outer-join}

It's my assumption that the result of a left or right join should include all the fields from both LHS and RHS (I could be wrong).  Added field checks to new join tests under this assumption.

Under this assumption, tests for left-join and right-join will not pass until the behavior is fixed.