### PR TITLE
fix(print): check if value is not nil before running .toString

### DIFF
--- a/src/tech/v3/dataset/print.clj
+++ b/src/tech/v3/dataset/print.clj
@@ -130,7 +130,7 @@ tech.ml.dataset.github-test> (def ds (with-meta ds
          column-width (or print-column-max-width *default-print-column-max-width*)
          column-types? (or print-column-types? *default-print-column-types?*)
          print-ds (ds-proto/select dataset :all index-range)
-         column-names (map #(.toString ^Object %) (keys print-ds))
+         column-names (map #(when (some? %) (.toString ^Object %)) (keys print-ds))
          column-types (map #(str (:datatype (meta %))) (vals print-ds))
          string-columns (map #(-> (dtype/->reader %)
                                   (packing/unpack)


### PR DESCRIPTION
This Pull Request will make the print dataset feature handle headers with `nil`values. 

This can occur when renaming columns and intentionally wanting to set the headers to `nil` values.