### PR TITLE
fix(fastexcel): confusing parameter name

### DIFF
--- a/src/tech/v3/libs/fastexcel.clj
+++ b/src/tech/v3/libs/fastexcel.clj
@@ -133,8 +133,8 @@
        (finally
          (when-not (identical? input workbook)
            (.close workbook))))))
-  ([workbook]
-   (workbook->datasets workbook {})))
+  ([input]
+   (workbook->datasets input {})))
 
 
 (defmethod ds-io/data->dataset :xlsx


### PR DESCRIPTION
The single parameter arity named `workbook` can be confusing. When consuming the function, it could be interpreted as it expects an instance of the Workbook data type. As returned by the function `input->workbook`.