### PR TITLE
Possibility to disable comment skipping when parsing CSV files

### DIFF
--- a/src/tech/v3/dataset/io.clj
+++ b/src/tech/v3/dataset/io.clj
@@ -134,6 +134,9 @@
      options. If the option is :carry-on then we either create a new column or add
      missing values for columns that had no data for that row.
   - `:skip-bad-rows?` - Legacy option.  Use :bad-row-policy.
+  - `:disable-comment-skipping?` - As default, the `#` character is recognised as a
+     line comment when found in the beginning of a line of text in a CSV file,
+     and the row will be ignored. Set `true` to disable this behavior.
   - `:max-chars-per-column` - Defaults to 4096.  Columns with more characters that this
      will result in an exception.
   - `:max-num-columns` - Defaults to 8192.  CSV,TSV files with more columns than this

--- a/src/tech/v3/dataset/io/univocity.clj
+++ b/src/tech/v3/dataset/io/univocity.clj
@@ -56,13 +56,23 @@
       (update :max-num-columns #(or % 8192))))
 
 
+
+(defn- apply-options-to-format!
+  ^CommonSettings [^CommonSettings settings {:keys [disable-comment-skipping?]}]
+  (when disable-comment-skipping?
+    (-> settings .getFormat (.setComment \0)))
+  settings)
+
+
+
 (defn- apply-options-to-settings!
   ^CommonSettings [^CommonSettings settings options]
   (let [{:keys [max-chars-per-column
                 max-num-columns]} (default-csv-options options)]
     (doto settings
       (.setMaxCharsPerColumn (long max-chars-per-column))
-      (.setMaxColumns (long max-num-columns))))
+      (.setMaxColumns (long max-num-columns))
+      (apply-options-to-format! options)))
   settings)
 
 


### PR DESCRIPTION
The default behavior in the `univocity` parser, is to recognise the `#` character as a line comment when found in the beginning of a line of text in a CSV file. The row will be ignored when parsing. 

This option will disable this behavior, when set to `true`.

Here's some context: https://github.com/uniVocity/univocity-parsers/blob/e09114c6879fa6c2c15e7365abc02cda3e193ff7/src/main/java/com/univocity/parsers/common/Format.java#L165