### PR TITLE
Upgrade inference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ Itemized Changes:
  * `assoc, ds/add-column, ds/update-column, ds/add-or-update-column` type operations all
     upgraded such that datatype and missing are inferred much more frequently.
  * `:tech.ml.dataset.parse/missing`, `:tech.ml.dataset.parse/parse-failure` -> `:tech.v3.dataset/missing`, `:tech.v3.dataset/parse-failure`.
+ * `column-map` - Now scans results to infer datatype if not provided as opposed to assuming result is the
+    widest of the input column types.  Also users can provide their own function that calculates missing sets as opposed to
+	the default behavior being the union of the input columns' missing sets.
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,41 @@
 # Changelog
 
+## 6.00
+
+ Data types and missing values are much more aggressively inferred - which is
+ `O(n-rows)`) throught the api. There is a new API to disable the inference - Either
+ pass something that is already a column or pass in a map with keys:
+```clojure
+  #:tech.v3.dataset{:data ... :missing ... :metadata ... :force-datatype? true}
+```
+  Put another way, the input to `#{assoc ds/update-column ds/add-column
+  ds/add-or-update-column}`  is already a column
+  (see `tech.v3.dataset.column/new-column`) or if `:tech.v3.dataset/force-datatype?` is
+  true **and** `:tech.v3.dataset/data` is convertible to a reader then the data will not
+  be scanned for datatype or missing values.  If the input data is a primitive-typed
+  container then it will be scanned for missing values alone and anything else is
+  passed through the object parsing system which is what is used for sequences of maps,
+  maps of sequences and spreadsheets.
+
+  In this way in general the system will do more work than before - more scans of the
+  result of things like transducer pathways and persistent vectors but in return the
+  dataset's column datatypes should match the user's expectations.  If too much time is
+  being taken up via attempting to infer datatypes and missing sets then the user has
+  the option to pass in explicitly constructed columns or column data representations
+  both of which will disable the scanning.  Once the data is typed elementwise
+  mathematical operations of the type in `:tech.v3.datatype.function` **will not**
+  result in further scans the data.
+
+
+Itemized Changes:
+
+ * `assoc, ds/add-column, ds/update-column, ds/add-or-update-column` type operations all
+    upgraded such that datatype and missing are inferred much more frequently.
+ * `:tech.ml.dataset.parse/missing`, `:tech.ml.dataset.parse/parse-failure` -> `:tech.v3.dataset/missing`, `:tech.v3.dataset/parse-failure`.
+
+
+
+
 ## 5.21
  * [Issue 233](https://github.com/techascent/tech.ml.dataset/issues/233) - Poi xlsx parser can now autodetect dates.  Note that fastexcel is the default
    xslx parser so in order to parse xlsx files using poi use `tech.v3.libs.poi/workbook->datasets`.
@@ -8,7 +44,7 @@
 
 ## 5.20
  * Return an Iterable from csv->rows as opposed to a seq.  Iterator-seq has nontrivial overhead.
- * Fixes for issues [229](https://github.com/techascent/tech.ml.dataset/issues/229), 
+ * Fixes for issues [229](https://github.com/techascent/tech.ml.dataset/issues/229),
    [230](https://github.com/techascent/tech.ml.dataset/issues/230), and [231](https://github.com/techascent/tech.ml.dataset/issues/231).
 
 ## 5.19
@@ -20,7 +56,7 @@
  * Parquet write pathway update to make more standard and more likely to work with future versions of parquet.  This means, however, that there will
    no longer be a direct correlation between number of datasets and number of record batches in a parquet file as the standard pathway takes care
    of writing out record batches when a memory constraint is triggered.  So if you save a dataset you may get a parquet file back that contains
-   a sequence of datasets.  There are many parquet options, see the documentation for 
+   a sequence of datasets.  There are many parquet options, see the documentation for
    [ds-seq->parquet](https://techascent.github.io/tech.ml.dataset/tech.v3.libs.parquet.html#var-ds-seq-.3Eparquet).
 
 ## 5.17

--- a/project.clj
+++ b/project.clj
@@ -3,8 +3,8 @@
   :url "http://github.com/techascent/tech.ml.dataset"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure              "1.10.2" :scope "provided"]
-                 [cnuernber/dtype-next             "7.10"]
+  :dependencies [[org.clojure/clojure              "1.10.3" :scope "provided"]
+                 [cnuernber/dtype-next             "7.11"]
                  [techascent/tech.io               "4.07"
                   :exclusions [org.apache.commons/commons-compress]]
                  [com.univocity/univocity-parsers  "2.9.0"]

--- a/src/tech/v3/dataset.clj
+++ b/src/tech/v3/dataset.clj
@@ -428,7 +428,6 @@ test/data/stocks.csv [5 4]:
    (column-map dataset result-colname map-fn nil (column-names dataset))))
 
 
-;; TODO - match inference expectations
 (defn column-cast
   "Cast a column to a new datatype.  This is never a lazy operation.  If the old
   and new datatypes match and no cast-fn is provided then dtype/clone is called

--- a/src/tech/v3/dataset.clj
+++ b/src/tech/v3/dataset.clj
@@ -382,11 +382,19 @@
   * `dataset` - dataset.
   * `result-colname` - Name of new (or existing) column.
   * `map-fn` - function to map over columns.  Same rules as `tech.v3.datatype/emap`.
-  * `res-dtype` - Defaults to the unified result of the input column datasets.
+  * `res-dtype-or-opts` - If not given result is scanned to infer missing and datatype.
+  If using an option map, options are described below.
   * `filter-fn-or-ds` - A dataset, a sequence of columns, or a `tech.v3.datasets/column-filters`
      column filter function.  Defaults to all the columns of the existing dataset.
 
   Returns a new dataset with a new or updated column.
+
+  Options:
+  * `:datatype` - Set the dataype of the result column.  If not given result is scanned
+  to infer result datatype and missing set.
+  * `:missing-fn` - if given, columns are first passed to missing-fn as a sequence and
+  this dictates the missing set.  Else the missing set is by scanning the results
+  during the inference process.
 
   Example:
 
@@ -418,10 +426,10 @@ test/data/stocks.csv [5 4]:
 |   MSFT | 2000-04-01 | 28.37 |  804.8569 |
 |   MSFT | 2000-05-01 | 25.45 |  647.7025 |
 ```"
-  ([dataset result-colname map-fn res-dtype filter-fn-or-ds]
+  ([dataset result-colname map-fn res-dtype-or-opts filter-fn-or-ds]
    (update dataset filter-fn-or-ds #(assoc % result-colname
                                            (apply ds-col/column-map map-fn
-                                                  res-dtype (columns %)))))
+                                                  res-dtype-or-opts (columns %)))))
   ([dataset result-colname map-fn filter-fn-or-ds]
    (column-map dataset result-colname map-fn nil filter-fn-or-ds))
   ([dataset result-colname map-fn]

--- a/src/tech/v3/dataset.clj
+++ b/src/tech/v3/dataset.clj
@@ -428,6 +428,7 @@ test/data/stocks.csv [5 4]:
    (column-map dataset result-colname map-fn nil (column-names dataset))))
 
 
+;; TODO - match inference expectations
 (defn column-cast
   "Cast a column to a new datatype.  This is never a lazy operation.  If the old
   and new datatypes match and no cast-fn is provided then dtype/clone is called
@@ -437,7 +438,7 @@ test/data/stocks.csv [5 4]:
 
   datatype may be a datatype enumeration or a tuple of
   [datatype cast-fn] where cast-fn may return either a new value,
-  :tech.v3.dataset.parse/missing, or :tech.v3.dataset.parse/parse-failure.
+  :tech.v3.dataset/missing, or :tech.v3.dataset/parse-failure.
   Exceptions are propagated to the caller.  The new column has at least the
   existing missing set (if no attempt returns :missing or :cast-failure).
   :cast-failure means the value gets added to metadata key :unparsed-data
@@ -499,11 +500,11 @@ test/data/stocks.csv [5 4]:
             (let [existing-val (col-reader idx)
                   new-val (cast-fn existing-val)]
               (cond
-                (= new-val :tech.ml.dataset.parse/missing)
+                (= new-val :tech.v3.dataset/missing)
                 (locking new-missing
                   (.add new-missing idx)
                   (res-writer idx missing-val))
-                (= new-val :tech.ml.dataset.parse/parse-failure)
+                (= new-val :tech.v3.dataset/parse-failure)
                 (locking new-missing
                   (res-writer idx missing-val)
                   (.add new-missing idx)

--- a/src/tech/v3/dataset/base.clj
+++ b/src/tech/v3/dataset/base.clj
@@ -693,10 +693,10 @@
                    col (if unpack?
                          (packing/unpack col)
                          col)]
-               (assoc ds colname {:data (dtype-cmc/->array col)
-                                  :missing (ds-col/missing col)
-                                  :metadata (meta col)
-                                  :force-datatype? true})))
+               (assoc ds colname #:tech.v3.dataset{:data (dtype-cmc/->array col)
+                                                   :missing (ds-col/missing col)
+                                                   :metadata (meta col)
+                                                   :force-datatype? true})))
            ds
            (columns ds)))
   ([ds]

--- a/src/tech/v3/dataset/base.clj
+++ b/src/tech/v3/dataset/base.clj
@@ -693,7 +693,10 @@
                    col (if unpack?
                          (packing/unpack col)
                          col)]
-               (assoc ds colname (dtype-cmc/->array col))))
+               (assoc ds colname {:data (dtype-cmc/->array col)
+                                  :missing (ds-col/missing col)
+                                  :metadata (meta col)
+                                  :force-datatype? true})))
            ds
            (columns ds)))
   ([ds]

--- a/src/tech/v3/dataset/column.clj
+++ b/src/tech/v3/dataset/column.clj
@@ -135,10 +135,8 @@ Implementations should check their metadata before doing calculations."
          n-elems (dtype/ecount col-reader)]
      (dotimes [iter n-elems]
        (column-parsers/add-value! col-parser iter (col-reader iter)))
-
-     (let [{:keys [data missing metadata]}
-           (column-parsers/finalize! col-parser n-elems)]
-       (new-column colname data metadata missing))))
+     (new-column (assoc (column-parsers/finalize! col-parser n-elems)
+                        :tech.v3.dataset/name colname))))
   ([datatype col]
    (parse-column datatype col nil)))
 

--- a/src/tech/v3/dataset/column.clj
+++ b/src/tech/v3/dataset/column.clj
@@ -113,14 +113,14 @@ Implementations should check their metadata before doing calculations."
       (catch Throwable e
         nil))))
 
-
+;; TODO - match inference expectations
 (defn parse-column
   "parse a text or a str column, returning a new column with the same name but with
   a different datatype.  This method is single-threaded.
 
   parser-fn-or-kwd is nil by default and can the keyword :relaxed?  or a function that
-  must return one of parsed-value, :tech.ml.dataset.parse/missing in which case a
-  missing value will be added or :tech.ml.dataset.parse/parse-failure in which case the
+  must return one of parsed-value, :tech.v3.dataset/missing in which case a
+  missing value will be added or :tech.v3.dataset/parse-failure in which case the
   a missing index will be added and the string value will be recorded in the metadata's
   :unparsed-data, :unparsed-indexes entries.
 
@@ -147,20 +147,13 @@ Implementations should check their metadata before doing calculations."
   "Create a new column.  Data will scanned for missing values
   unless the full 4-argument pathway is used."
   ([name data]
-   (let [{coldata :data
-          scanned-missing :missing}
-         (column-data-process/scan-data-for-missing data)]
-     (new-column name coldata nil scanned-missing)))
+   (col-impl/new-column name data))
   ([name data metadata]
-   (let [{coldata :data
-          scanned-missing :missing}
-         (column-data-process/scan-data-for-missing data)]
-     (new-column name coldata metadata scanned-missing)))
+   (col-impl/new-column name data metadata))
   ([name data metadata missing]
-   (let [data (if-not (dtype/as-buffer data)
-                (:data (column-data-process/scan-data-for-missing data))
-                data)]
-     (col-impl/new-column name data metadata missing))))
+   (col-impl/new-column name data metadata missing))
+  ([data-or-data-map]
+   (col-impl/new-column data-or-data-map)))
 
 
 (defn extend-column-with-empty

--- a/src/tech/v3/dataset/impl/column.clj
+++ b/src/tech/v3/dataset/impl/column.clj
@@ -245,6 +245,12 @@
                data
                metadata
                nil)))
+  (buffer [this] data)
+  (as-map [this] #:tech.v3.dataset{:name (:name metadata)
+                                   :data data
+                                   :missing missing
+                                   :metadata metadata
+                                   :force-datatype? true})
   (unique [this]
     (->> (parallel-unique this)
          (into #{})))

--- a/src/tech/v3/dataset/impl/column_data_process.clj
+++ b/src/tech/v3/dataset/impl/column_data_process.clj
@@ -95,8 +95,8 @@
            {:tech.v3.dataset/data data
             :tech.v3.dataset/missing (if missing missing (scan-missing data))}
            (scan-data data missing))
-         ;;allow missing/metadata to make it through
-         (dissoc obj-data :tech.v3.dataset/data :tech.v3.dataset/missing)
+         ;;allow missing/metadata to make it through so user can override
+         (dissoc obj-data :tech.v3.dataset/data)
          #:tech.v3.dataset{:force-datatype? true})))
     (col-proto/is-column? obj-data)
     (col-proto/as-map obj-data)

--- a/src/tech/v3/dataset/impl/column_data_process.clj
+++ b/src/tech/v3/dataset/impl/column_data_process.clj
@@ -1,63 +1,105 @@
 (ns tech.v3.dataset.impl.column-data-process
   (:require [tech.v3.datatype :as dtype]
+            [tech.v3.datatype.errors :as errors]
             [tech.v3.datatype.bitmap :as bitmap]
-            [tech.v3.datatype.casting :as casting]
             [tech.v3.parallel.for :as parallel-for]
+            [tech.v3.protocols.column :as col-proto]
+            [tech.v3.dataset.io.column-parsers :as column-parsers]
             [tech.v3.dataset.impl.column-base :as column-base])
-  (:import [tech.v3.datatype PrimitiveList]))
+  (:import [tech.v3.datatype PrimitiveList]
+           [org.roaringbitmap RoaringBitmap]
+           [java.util Map Objects]))
 
 
 (set! *warn-on-reflection* true)
 (set! *unchecked-math* :warn-on-boxed)
 
 
-(def object-primitive-array-types
-  {(Class/forName "[Ljava.lang.Boolean;") :boolean
-   (Class/forName "[Ljava.lang.Byte;") :int8
-   (Class/forName "[Ljava.lang.Short;") :int16
-   (Class/forName "[Ljava.lang.Character;") :char
-   (Class/forName "[Ljava.lang.Integer;") :int32
-   (Class/forName "[Ljava.lang.Long;") :int64
-   (Class/forName "[Ljava.lang.Float;") :float32
-   (Class/forName "[Ljava.lang.Double;") :float64})
+(defmacro missing-value?
+  "Is this a missing value given the datatype-specific column missing value"
+  [missing-value obj]
+  `(and (not (instance? Boolean ~obj))
+        (or (nil? ~obj)
+            (Objects/equals ~missing-value ~obj)
+            (identical? :tech.v3.dataset/missing ~obj)
+            (identical? :tech.v3.dataset/parse-failure ~obj))))
 
 
-(defn scan-data-for-missing
-  "Scan container for missing values.  Returns a map of
-  {:data :missing}"
+(defn scan-missing
+  "Scan a (potentially primitive) reader for missing values.  This simply scans every
+  value in the reader."
+  ^RoaringBitmap [rdr]
+  (let [rdr (dtype/->reader rdr)
+        missing (column-base/datatype->missing-value (dtype/elemwise-datatype rdr))]
+    (parallel-for/indexed-map-reduce
+     (.lsize rdr)
+     (fn [^long start-idx ^long group-len]
+       (let [bmp (bitmap/->bitmap)]
+         (dotimes [group-idx group-len]
+           (let [idx (+ group-idx start-idx)
+                 obj (.readObject rdr idx)]
+             (when (missing-value? missing obj)
+               (.add bmp idx))))
+         bmp))
+     (fn [bmps]
+       (let [^RoaringBitmap bmp (first bmps)]
+         (doseq [^RoaringBitmap other-bmp (rest bmps)]
+           (.or bmp other-bmp))
+         bmp)))))
+
+
+(defn prepare-column-data
+  "Scan data for missing values and to infer storage datatype.  Returns
+   a map of least #tech.v3.dataset{:data :missing :force-datatype?}."
   [obj-data]
-  (let [obj-data-datatype (dtype/elemwise-datatype obj-data)]
-    (if (and (dtype/reader? obj-data)
-             (not= :object (casting/flatten-datatype obj-data-datatype)))
-      {:data obj-data
-       :missing (bitmap/->bitmap)}
-      (let [dst-container-type (get object-primitive-array-types
-                                    (type obj-data)
-                                    (dtype/elemwise-datatype obj-data))
-            sparse-val (get column-base/dtype->missing-val-map dst-container-type)
-            sparse-indexes (bitmap/->bitmap)]
-        (if-let [obj-data (dtype/as-reader obj-data)]
-          (let [n-items (dtype/ecount obj-data)
-                dst-data (dtype/make-container :jvm-heap dst-container-type n-items)
-                dst-io (dtype/->buffer dst-data)]
-            (parallel-for/parallel-for
-             idx
-             n-items
-             (let [obj-data (.readObject obj-data idx)]
-               (if (not (nil? obj-data))
-                 (.writeObject dst-io idx obj-data)
-                 (locking sparse-indexes
-                   (.add sparse-indexes idx)
-                   (.writeObject dst-io idx sparse-val)))))
-            {:data dst-data
-             :missing sparse-indexes})
-          (let [^PrimitiveList dst-data (dtype/make-container :list dst-container-type 0)]
-            (parallel-for/consume!
-             #(if-not (nil? %)
-                (.addObject dst-data %)
-                (let [idx (.size dst-data)]
-                  (.add sparse-indexes idx)
-                  (.addObject dst-data sparse-val)))
-             obj-data)
-            {:data dst-data
-             :missing sparse-indexes}))))))
+  (cond
+    (map? obj-data)
+    (do
+      (errors/when-not-errorf
+       (contains? ^Map obj-data :tech.v3.dataset/data)
+       "Map constructors must contain at least :tech.v3.dataset/data")
+      ;;ensure we do not re-scan this object
+      (merge
+       (if (and (obj-data :tech.v3.dataset/force-datatype?)
+                (dtype/reader? (obj-data :tech.v3.dataset/data)))
+         ;;skip scan of the data
+         obj-data
+         (prepare-column-data (obj-data :tech.v3.dataset/data)))
+       ;;allow missing/metadata to make it through
+       (dissoc obj-data :tech.v3.dataset/data)
+       #:tech.v3.dataset{:force-datatype? true}))
+    (col-proto/is-column? obj-data)
+    #:tech.v3.dataset{:name (:name (meta obj-data))
+                      :data (dtype/->buffer obj-data)
+                      :missing (col-proto/missing obj-data)
+                      :metdata (meta obj-data)}
+    :else
+    (let [obj-data-datatype (dtype/elemwise-datatype obj-data)]
+      (if (and (dtype/reader? obj-data)
+               (not= :object obj-data-datatype))
+        ;;If the user knows the datatype they want, then we just scan for missing.
+        #:tech.v3.dataset{:data obj-data
+                          :force-datatype? true
+                          :missing (scan-missing obj-data)}
+        (let [obj-meta (meta obj-data)
+              parser (column-parsers/promotional-object-parser
+                      (:name obj-meta) obj-meta)
+              ;;At this point either you are convertible to a reader or you are
+              ;;iterable.
+              obj-data (or (dtype/as-reader obj-data) obj-data)]
+          ;;serially consume the data promoting the container when necessary.
+          (parallel-for/indexed-consume!
+           #(column-parsers/add-value! parser %1 %2)
+           obj-data)
+          (column-parsers/finalize! parser (dtype/ecount parser)))))))
+
+
+(defn prepare-column-data-seq
+  [column-seq]
+  (pmap (fn [idx item]
+          (-> (if (map? item)
+                (update item :tech.v3.dataset/name
+                        #(or % idx))
+                item)
+              (prepare-column-data)))
+        (range) column-seq))

--- a/src/tech/v3/dataset/io.clj
+++ b/src/tech/v3/dataset/io.clj
@@ -164,8 +164,8 @@
                  parse functions do not stop the parsing process.  :unparsed-values and
                  :unparsed-indexes are available in the metadata of the column that tell
                  you the values that failed to parse and their respective indexes.
-              - `fn?` - function from str-> one of `:tech.ml.dataset.parse/missing`,
-                 `:tech.ml.dataset.parse/parse-failure`, or the parsed value.
+              - `fn?` - function from str-> one of `:tech.v3.dataset/missing`,
+                 `:tech.v3.dataset/parse-failure`, or the parsed value.
                  Exceptions here always kill the parse process.  :missing will get marked
                  in the missing indexes, and :parse-failure will result in the index being
                  added to missing, the unparsed the column's :unparsed-values and

--- a/src/tech/v3/dataset/io.clj
+++ b/src/tech/v3/dataset/io.clj
@@ -211,7 +211,9 @@
            ;;Not everything has a conversion to seq.
            (instance? Map (try (first (seq dataset))
                                (catch Throwable e nil)))
-           (parse-mapseq-colmap/mapseq->dataset options dataset)
+           (try
+             "HERE!!!!"
+             (parse-mapseq-colmap/mapseq->dataset options dataset))
            (nil? (seq dataset))
            (ds-impl/new-dataset options nil))]
      (if dataset-name

--- a/src/tech/v3/dataset/io/context.clj
+++ b/src/tech/v3/dataset/io/context.clj
@@ -101,7 +101,7 @@
      (->> all-parsers
           (mapv (fn [{:keys [column-name column-parser]}]
                   (assoc (column-parsers/finalize! column-parser row-count)
-                         :name column-name)))
+                         :tech.v3.dataset/name column-name)))
           (ds-impl/new-dataset options))))
   ([options parsers]
    (parsers->dataset options parsers

--- a/src/tech/v3/dataset/io/mapseq_colmap.clj
+++ b/src/tech/v3/dataset/io/mapseq_colmap.clj
@@ -68,19 +68,19 @@
                              (take n-rows coldata)
                              coldata)]
                (if (= :scalar argtype)
-                 {:name colname
-                  :data (dtype/const-reader coldata n-rows)}
+                 #:tech.v3.dataset{:name colname
+                                   :data (dtype/const-reader coldata n-rows)}
                  (if (and (= :reader argtype)
                           (not= :object (dtype/elemwise-datatype coldata)))
-                   {:name colname
-                    :data coldata}
+                   #:tech.v3.dataset{:name colname
+                                     :data coldata}
                    ;;Actually attempt to parse the data
                    (let [parser (parse-context colname)]
                      (pfor/consume!
                       #(column-parsers/add-value! parser (first %) (second %))
                       (map-indexed vector coldata))
                      (assoc (column-parsers/finalize! parser (dtype/ecount parser))
-                            :name colname)))))))
+                            :tech.v3.dataset/name colname)))))))
           (ds-impl/new-dataset options))))
   ([column-map]
    (column-map->dataset nil column-map)))

--- a/src/tech/v3/dataset/io/univocity.clj
+++ b/src/tech/v3/dataset/io/univocity.clj
@@ -204,7 +204,7 @@
    :data typed reader/writer of data
    :metadata - optional map with unparsed-indexes and unparsed-values
   }
-  Supports a subset of tech.ml.dataset/->dataset options:
+  Supports a subset of tech.v3.dataset/->dataset options:
   :column-whitelist
   :column-blacklist
   :n-initial-skip-rows

--- a/src/tech/v3/dataset/neanderthal.clj
+++ b/src/tech/v3/dataset/neanderthal.clj
@@ -37,7 +37,7 @@
 
 (defn dense->dataset
   "Given a neanderthal matrix, convert its columns into the columns of a
-  tech.ml.dataset.  This does the conversion in-place.  If you would like to copy
+  tech.v3.dataset.  This does the conversion in-place.  If you would like to copy
   the neanderthal matrix into JVM arrays, then after method use dtype/clone."
   [matrix]
   (->> (n-core/cols matrix)

--- a/src/tech/v3/dataset/print.clj
+++ b/src/tech/v3/dataset/print.clj
@@ -120,7 +120,8 @@ tech.ml.dataset.github-test> (def ds (with-meta ds
   ([dataset]
    (dataset-data->str dataset {}))
   ([dataset options]
-   (let [{:keys [print-index-range print-line-policy print-column-max-width print-column-types?]}
+   (let [{:keys [print-index-range print-line-policy
+                 print-column-max-width print-column-types?]}
          (merge (meta dataset) options)
          index-range (or print-index-range
                          (range
@@ -131,7 +132,8 @@ tech.ml.dataset.github-test> (def ds (with-meta ds
          column-types? (or print-column-types? *default-print-column-types?*)
          print-ds (ds-proto/select dataset :all index-range)
          column-names (map #(when (some? %) (.toString ^Object %)) (keys print-ds))
-         column-types (map #(str (:datatype (meta %))) (vals print-ds))
+         column-types (map #(str (when column-types? (:datatype (meta %))))
+                           (vals print-ds))
          string-columns (map #(-> (dtype/->reader %)
                                   (packing/unpack)
                                   (reader->string-lines (ds-col-proto/missing %)
@@ -142,6 +144,7 @@ tech.ml.dataset.github-test> (def ds (with-meta ds
                                   (dtype/clone)
                                   (dtype/->reader))
                              (vals print-ds))
+
          n-rows (long (second (dtype/shape print-ds)))
          row-heights (ArrayList.)
          _ (.addAll row-heights (repeat n-rows 1))
@@ -184,8 +187,8 @@ tech.ml.dataset.github-test> (def ds (with-meta ds
                                          (if numeric?
                                            ":"
                                            "-"))))
-                             spacers (map dtype/get-datatype
-                                          print-ds))
+                             spacers (map dtype/elemwise-datatype
+                                          (vals print-ds)))
                      ["|"])))
      (dotimes [idx n-rows]
        (let [row-height (long (.get row-heights idx))]

--- a/src/tech/v3/dataset/reductions/impl.clj
+++ b/src/tech/v3/dataset/reductions/impl.clj
@@ -423,6 +423,7 @@ tech.v3.dataset.reductions> (group-by-column-agg
          (let [^ResDsCtx ctx ctx]
            (ds-impl/new-dataset options
                                 (map (fn [colname ^ResDsColData col-data]
+                                       #:tech.v3.dataset
                                        {:name colname
                                         :data (.col-data col-data)
                                         :missing (.missing col-data)

--- a/src/tech/v3/libs/parquet.clj
+++ b/src/tech/v3/libs/parquet.clj
@@ -376,7 +376,7 @@ https://gist.github.com/animeshtrivedi/76de64f9dab1453958e1d4f8eca1605f"
         ^Buffer row-rep-counts (when-not (== n-rows (.getTotalValueCount col-rdr))
                                  (-> (int-array n-rows)
                                      (dtype/->buffer)))
-        {:keys [data missing metadata]}
+        coldata
         ;;The user specified a specific parser for this datatype
         (loop [continue? (.hasNext iterator)
                row-idx -1
@@ -390,10 +390,12 @@ https://gist.github.com/animeshtrivedi/76de64f9dab1453958e1d4f8eca1605f"
                 (.accumPlusLong row-rep-counts row-idx 1))
               (recur (.hasNext iterator) row-idx (unchecked-inc row)))
             (col-parsers/finalize! col-parser n-rows)))]
-    (col-impl/new-column (key-fn col-name) data
-                         (merge metadata (when row-rep-counts
-                                           {:row-rep-counts row-rep-counts}))
-                         missing)))
+    (col-impl/new-column (cond-> (assoc coldata
+                                        :tech.v3.dataset/name
+                                        (key-fn col-name))
+                           row-rep-counts
+                           (update :tech.v3.dataset/metadata
+                                   assoc :row-rep-counts row-rep-counts)))))
 
 
 (defn- parse-parquet-column

--- a/src/tech/v3/libs/parquet.clj
+++ b/src/tech/v3/libs/parquet.clj
@@ -136,7 +136,7 @@ https://gist.github.com/animeshtrivedi/76de64f9dab1453958e1d4f8eca1605f"
     (if (> n-rows 0)
       (let [retval (if (== max-def-level (.getCurrentDefinitionLevel col-rdr))
                      (read-fn col-rdr)
-                     :tech.ml.dataset.parse/missing)]
+                     :tech.v3.dataset/missing)]
         (set! n-rows (dec n-rows))
         (.consume col-rdr)
         retval)
@@ -354,7 +354,7 @@ https://gist.github.com/animeshtrivedi/76de64f9dab1453958e1d4f8eca1605f"
         missing (bitmap/->bitmap)]
     (reify col-parsers/PParser
       (add-value! [p idx value]
-        (if (= value :tech.ml.dataset.parse/missing)
+        (if (= value :tech.v3.dataset/missing)
           (do
             (.addObject container missing-value)
             (.add missing (long idx)))

--- a/src/tech/v3/protocols/column.clj
+++ b/src/tech/v3/protocols/column.clj
@@ -22,6 +22,11 @@
     "Return true if this index is missing.")
   (set-missing [col long-rdr]
     "Set this group of indexes as the missing set")
+  (buffer [col]
+    "Return the data buffer (if there is one) backing this column")
+  (as-map [col]
+    "Return data map representation of this column.  That representation must
+contain at least #:tech.v3.dataset{:name :data :missing :metadata}")
   (unique [col]
     "Set of all unique values")
   (stats [col stats-set]

--- a/test/tech/v3/dataset/infer_test.clj
+++ b/test/tech/v3/dataset/infer_test.clj
@@ -19,6 +19,8 @@
     (inferred-equals #:tech.v3.dataset{:data [1 2 3 nil 4]
                                        :force-datatype? true}
                      [1 2 3 nil 4])
+    (inferred-equals (list 0 Double/NaN 1 nil nil)
+                     (double-array [0.0 Double/NaN 1.0 Double/NaN Double/NaN]))
     (is (= #{2 4}
            (set (ds/missing (-> (ds/->dataset [])
                                 (assoc :test-data [1 2 nil 3 nil]))))))

--- a/test/tech/v3/dataset/infer_test.clj
+++ b/test/tech/v3/dataset/infer_test.clj
@@ -1,0 +1,43 @@
+(ns tech.v3.dataset.infer-test
+  (:require [tech.v3.dataset :as ds]
+            [tech.v3.datatype :as dtype]
+            [tech.v3.datatype.functional :as dfn]
+            [tech.v3.datatype.bitmap :as bitmap]
+            [clojure.test :refer [deftest is]]))
+
+
+(deftest simple-inference
+  (letfn [(inferred-equals [lhs rhs]
+            (let [test-col (-> (ds/->dataset [])
+                               (assoc :testdata lhs)
+                               (:testdata))]
+              (is (= (dtype/elemwise-datatype test-col)
+                     (dtype/elemwise-datatype rhs)))
+              (is (every? identity (dfn/eq test-col rhs)))))]
+    (inferred-equals [true false true false] (boolean-array [true false true false]))
+    (inferred-equals (list 0 Double/NaN 1) (double-array [0.0 Double/NaN 1.0]))
+    (inferred-equals #:tech.v3.dataset{:data [1 2 3 nil 4]
+                                       :force-datatype? true}
+                     [1 2 3 nil 4])
+    (is (= #{2 4}
+           (set (ds/missing (-> (ds/->dataset [])
+                                (assoc :test-data [1 2 nil 3 nil]))))))
+    (is (= #{2 4}
+           (set (ds/missing
+                 (-> (ds/->dataset [])
+                     (assoc :test-data #:tech.v3.dataset{:data [1 2 nil 3 nil]
+                                                         :force-datatype? true}))))))
+    (is
+     (= #{}
+        (set (ds/missing
+              (-> (ds/->dataset [])
+                  (assoc :test-data #:tech.v3.dataset{:data [1 2 nil 3 nil]
+                                                      :force-datatype? true
+                                                      :missing (bitmap/->bitmap)}))))))
+    (is
+     (= #{}
+        (set (ds/missing
+              (-> (ds/->dataset [])
+                  (assoc :test-data #:tech.v3.dataset{:data [1 2 nil 3 nil]
+                                                      :missing (bitmap/->bitmap)}))))))
+    ))

--- a/test/tech/v3/dataset/parse_test.clj
+++ b/test/tech/v3/dataset/parse_test.clj
@@ -418,9 +418,9 @@
                                 (fn [str-val]
                                   (cond
                                     (= str-val "missing")
-                                    :tech.ml.dataset.parse/missing
+                                    :tech.v3.dataset/missing
                                     (= str-val "parse-failure")
-                                    :tech.ml.dataset.parse/parse-failure
+                                    :tech.v3.dataset/parse-failure
                                     :else
                                     (Long/parseLong str-val)))]}})]
       (is (= [1 nil nil 2 3]

--- a/test/tech/v3/dataset/reductions_test.clj
+++ b/test/tech/v3/dataset/reductions_test.clj
@@ -91,7 +91,7 @@
 
 
 (deftest reservoir-sampling-test
-  #_(let [stocks (ds/->dataset "test/data/stocks.csv" {:key-fn keyword})
+  (let [stocks (ds/->dataset "test/data/stocks.csv" {:key-fn keyword})
         ds-seq [stocks stocks stocks]
         small-ds-seq [(-> (ds/shuffle stocks)
                           (ds/select-rows (range 50)))]

--- a/test/tech/v3/dataset_test.clj
+++ b/test/tech/v3/dataset_test.clj
@@ -453,7 +453,7 @@
 (deftest mean-object-column
   (let [ds (-> (ds/->dataset [])
                (ds/add-or-update-column :a (map (fn [arg] (* 2 arg)) (range 9))))]
-    (is (= :object (dtype/get-datatype (ds :a))))
+    (is (= :int64 (dtype/get-datatype (ds :a))))
     (is (= 8.0 (dfn/mean (ds :a))))))
 
 

--- a/test/tech/v3/dataset_test.clj
+++ b/test/tech/v3/dataset_test.clj
@@ -440,11 +440,35 @@
 
 (deftest typed-column-map-missing
   (let [ds (ds/bind-> (ds/->dataset [{:a 1} {:b 2.0} {:a 2 :b 3.0}]) ds
-             (assoc :a
-                    (ds-col/column-map (fn ^double [^double lhs ^double rhs]
-                                         (+ lhs rhs))
-                                       :float64
-                                       (ds :a) (ds :b))))]
+             (assoc :a (ds-col/column-map (fn [lhs rhs]
+                                            (when (and lhs rhs)
+                                              (+ (double lhs)
+                                                 (double rhs))))
+                                          nil
+                                          (ds :a) (ds :b))))]
+    (is (= :float64 (dtype/get-datatype (ds :a))))
+    (is (= [false false true]
+           (vec (dfn/finite? (ds :a))))))
+
+  (let [ds (ds/bind-> (ds/->dataset [{:a 1} {:b 2.0} {:a 2 :b 3.0}]) ds
+             (assoc :a (ds-col/column-map (fn [lhs rhs]
+                                            (if (and lhs rhs)
+                                              (+ (double lhs)
+                                                 (double rhs))
+                                              Double/NaN))
+                                          :float64
+                                          (ds :a) (ds :b))))]
+    (is (= :float64 (dtype/get-datatype (ds :a))))
+    (is (= [false false true]
+           (vec (dfn/finite? (ds :a))))))
+
+  (let [ds (ds/bind-> (ds/->dataset [{:a 1} {:b 2.0} {:a 2 :b 3.0}]) ds
+             (assoc :a (ds-col/column-map (fn [^double lhs ^double rhs]
+                                            (+ (double lhs)
+                                               (double rhs)))
+                                          {:missing-fn ds-col/union-missing-sets
+                                           :datatype :float64}
+                                          (ds :a) (ds :b))))]
     (is (= :float64 (dtype/get-datatype (ds :a))))
     (is (= [false false true]
            (vec (dfn/finite? (ds :a)))))))


### PR DESCRIPTION
The dataset library will now infer datatype and missing sets in many more situations.  The benefits of this are much more correctness while the detriments are that there are hidden performance issues.

Reports from the field are that the library performs more than well enough however (meaning we have cpu cycles to burn) and that trying to implement datatype-specific algorithms such as indexing is tough because often the datatype ends up as `:object`.

Literally every single power user has hinted or talked about this at one time or another in that they are confused when a map or vector added to the dataset doesn't get scanned.