### PR TITLE
Set Unicode zero (\u0000) to disable comment skipping

### DIFF
--- a/src/tech/v3/dataset/io/univocity.clj
+++ b/src/tech/v3/dataset/io/univocity.clj
@@ -60,7 +60,7 @@
 (defn- apply-options-to-format!
   ^CommonSettings [^CommonSettings settings {:keys [disable-comment-skipping?]}]
   (when disable-comment-skipping?
-    (-> settings .getFormat (.setComment \0)))
+    (-> settings .getFormat (.setComment \u0000)))
   settings)
 
 


### PR DESCRIPTION
The[ Univocity docs](http://docs.univocity.com/parser/html/2.1.0/com/univocity/parsers/common/Format.html#setComment-char-) describe the use of the `\0` char to disable comment skipping, but it turns out that one will treat rows with leading zeros as comments.

This PR will set Unicode zero as the "comment" char to prevent this.

There is also an issue (closed) in the Univocity repo related to this behaviour:
https://github.com/uniVocity/univocity-parsers/issues/362


Co-authored-by: Ola Edin <olaedin@gmail.com>
Co-authored-by: Joakim Tengstrand <joakim@funnel.io>