### PR TITLE
Allow Column `select` to support logical buffers

### DIFF
--- a/src/tech/v3/dataset/impl/column.clj
+++ b/src/tech/v3/dataset/impl/column.clj
@@ -329,7 +329,9 @@
       :spearman (dfn/spearmans-correlation col other-column)
       :kendall (dfn/kendalls-correlation col other-column)))
   (select [col idx-rdr]
-    (let [idx-rdr (->efficient-reader idx-rdr)]
+    (let [idx-rdr (if (= (dtype/elemwise-datatype idx-rdr) :boolean)
+                    (->efficient-reader (keep-indexed #(when (true? %2) %1) idx-rdr))
+                    (->efficient-reader idx-rdr))]
       (if (== 0 (dtype/ecount missing))
         ;;common case
         (let [bitmap (->bitmap)


### PR DESCRIPTION
# Goal

Allow tech.ml.dataset's column `select` method to support logical buffers. This would make this kind of convenient selection available, which _I think_ may not currently be possible:

```clj
  (def x (new-column [1 nil 3 4 5 6 7]))

  x

  (.select x (fun/not (fun/nan? x)))
  ;; => #tech.v3.dataset.column<int64>[6]
  ;;    null
  ;;    [1, 3, 4, 5, 6, 7]

  (.select x (fun/> x 5))
  ;; => #tech.v3.dataset.column<int64>[2]
  ;;    null
  ;;    [6, 7]
```
This is convenient, and it will also be familiar to users of R and Python who can do this:
```r
```