### PR TITLE
`[select-sum]` Perf

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure              "1.11.1" :scope "provided"]
                  [cnuernber/dtype-next             "9.033"]
-                 [com.cnuernber/ham-fisted         "1.000-beta-38"]
+                 [com.cnuernber/ham-fisted         "1.000-beta-39"]
                  [techascent/tech.io               "4.21"
                   :exclusions [org.apache.commons/commons-compress]]
                  ;;[com.cnuernber/charred            "1.011"]

--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure              "1.11.1" :scope "provided"]
                  [cnuernber/dtype-next             "9.033"]
-                 [com.cnuernber/ham-fisted         "1.000-beta-39"]
+                 [com.cnuernber/ham-fisted         "1.000-beta-40"]
                  [techascent/tech.io               "4.21"
                   :exclusions [org.apache.commons/commons-compress]]
                  ;;[com.cnuernber/charred            "1.011"]

--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure              "1.11.1" :scope "provided"]
                  [cnuernber/dtype-next             "9.033"]
-                 [com.cnuernber/ham-fisted         "1.000-beta-40"]
+                 [com.cnuernber/ham-fisted         "1.000-beta-41"]
                  [techascent/tech.io               "4.21"
                   :exclusions [org.apache.commons/commons-compress]]
                  ;;[com.cnuernber/charred            "1.011"]

--- a/project.clj
+++ b/project.clj
@@ -5,6 +5,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure              "1.11.1" :scope "provided"]
                  [cnuernber/dtype-next             "9.033"]
+                 [com.cnuernber/ham-fisted         "1.000-beta-38"]
                  [techascent/tech.io               "4.21"
                   :exclusions [org.apache.commons/commons-compress]]
                  ;;[com.cnuernber/charred            "1.011"]

--- a/test/tech/v3/dataset_test.clj
+++ b/test/tech/v3/dataset_test.clj
@@ -1629,7 +1629,7 @@
     (dotimes [_ 100000]
       (reduce #(+ %1 (nth col %2))
               0.0
-              (hamf/int-array (select-sum-obtain-ten-indexes))))))
+              (hamf/->collection (select-sum-obtain-ten-indexes))))))
 
 (defn- select-sum-hamf
   [ds]

--- a/test/tech/v3/dataset_test.clj
+++ b/test/tech/v3/dataset_test.clj
@@ -1635,9 +1635,11 @@
   [ds]
   (let [col (hamf/double-array (:x0 ds))]
     (dotimes [_ 100000]
-      (->> (select-sum-obtain-ten-indexes)
-           (lznc/map (hamf/long-to-double-function idx (aget col (unchecked-int idx))))
-           (hamf/reduce-reducer (ham_fisted.Sum$SimpleSum.))))))
+      (hamf/reduce (hamf/long-accumulator
+                    acc v
+                    (+ (double acc) (aget col (unchecked-int v))))
+                   0.0
+                   (select-sum-obtain-ten-indexes)))))
 
 (defn select-sum-perf!
   []

--- a/test/tech/v3/dataset_test.clj
+++ b/test/tech/v3/dataset_test.clj
@@ -1595,7 +1595,7 @@
       (if (< (.size a) 10)
         (do (.add a (.nextInt ^Random random 1000))
             (recur))
-        (hamf/vec (.toArray a))))))
+        a))))
 
 (defn- select-sum-select-rows
   [ds]
@@ -1615,7 +1615,8 @@
   [ds]
   (let [col (:x0 ds)]
     (dotimes [_ 100000]
-      (-> (dtype/indexed-buffer (select-sum-obtain-ten-indexes) col)
+      ;;The other pathways either do this themselves or do not need it.
+      (-> (dtype/indexed-buffer (vec (select-sum-obtain-ten-indexes)) col)
           (dfn/sum-fast)))))
 
 

--- a/test/tech/v3/dataset_test.clj
+++ b/test/tech/v3/dataset_test.clj
@@ -1623,6 +1623,13 @@
       (-> (dtype/indexed-buffer (hamf/int-array (select-sum-obtain-ten-indexes)) col)
           (dfn/sum-fast)))))
 
+(defn- select-sum-clj-reduce
+  [ds]
+  (let [col (:x0 ds)]
+    (dotimes [_ 100000]
+      (reduce #(+ %1 (nth col %2))
+              0.0
+              (hamf/int-array (select-sum-obtain-ten-indexes))))))
 
 (defn- select-sum-hamf
   [ds]
@@ -1632,17 +1639,16 @@
            (lznc/map (hamf/long-to-double-function idx (aget col (unchecked-int idx))))
            (hamf/reduce-reducer (ham_fisted.Sum$SimpleSum.))))))
 
-
-
 (defn select-sum-perf!
   []
   (let [t (fn [description f]
             (let [start-nanos (System/nanoTime)]
               (f)
               (let [elapsed-sec (/ (- (System/nanoTime) start-nanos) 1e9)]
-                (println (format "select-sum: %s in %.2fs" description elapsed-sec)))))
+                (println (format "select-sum: %-14s in %.2fs" description elapsed-sec)))))
         ds (select-sum-obtain-ds)]
     (t "select-rows" #(select-sum-select-rows ds))
     (t "tensor-select" #(select-sum-tensor-select ds))
     (t "indexed-buffer" #(select-sum-indexed-buffer ds))
+    (t "clj-reduce" #(select-sum-clj-reduce ds))
     (t "hamf-mapreduce" #(select-sum-hamf ds))))


### PR DESCRIPTION
    tech.v3.dataset-test> (select-sum-perf!)
    select-sum: select-rows in 6.93s
    select-sum: tensor-select in 1.35s
    select-sum: indexed-buffer in 0.23s
    nil

---

`indexed-buffer` is winning so far.

`select-rows` does a lot more work (builds up a whole new dataset) so it makes sense it's slower

`tensor-select` may have some room for improvement, or not

---

Interesting, to me, to see the difference in speeds here, since they're accomplishing the same thing (adding up 10 out of 1000 numbers)