### PR TITLE
added 'as: opts' to 2 function signatures

### DIFF
--- a/src/tech/v3/dataset/categorical.clj
+++ b/src/tech/v3/dataset/categorical.clj
@@ -152,7 +152,7 @@ Non integers found: " (vec bad-mappings)))))
 
 (defn invert-categorical-map
   "Invert a categorical map returning the column to the original set of values."
-  [dataset {:keys [src-column lookup-table]}]
+  [dataset {:keys [src-column lookup-table] :as opts}]
   (let [column (ds-base/column dataset src-column)
         res-dtype (reduce casting/widest-datatype
                           (map dtype/datatype (keys lookup-table)))
@@ -254,7 +254,7 @@ Non integers found: " (vec bad-mappings)))))
 (defn invert-one-hot-map
   "Invert a one-hot transformation removing the one-hot columns and adding back the
   original column."
-  [dataset {:keys [one-hot-table src-column]}]
+  [dataset {:keys [one-hot-table src-column] :as opts}]
   (let [cast-fn (get @casting/*cast-table* :boolean)
         invert-map (set/map-invert one-hot-table)
         colnames (vec (keys invert-map))


### PR DESCRIPTION
I want to generate the `scicloj.ml` namespaces via `tech.v3.datatype.export-symbols/write-api!`

2 functions I want to export are from here and seem to have "incompatible" signatures for the exporter as they miss the ":as" in keyword deconstruction.

This PR add ":as opts" to the 2 functions I had failing to export.

I am **not 100 % sure** that this is a full backwards compatible change, but I believe so.