### PR TITLE
`[dataset]` print-all helper

### DIFF
--- a/src/tech/v3/dataset.clj
+++ b/src/tech/v3/dataset.clj
@@ -836,6 +836,12 @@ test/data/stocks.csv [10 3]:
   (tech.v3.dataset-api/pmap-ds ds ds-map-fn)))
 
 
+(defn print-all
+  "Helper function equivalent to `(tech.v3.dataset.print/print-range ... :all)`"
+  ([dataset]
+  (tech.v3.dataset-api/print-all dataset)))
+
+
 (defn rand-nth
   "Return a random row from the dataset in map format"
   ([dataset]

--- a/src/tech/v3/dataset_api.clj
+++ b/src/tech/v3/dataset_api.clj
@@ -308,6 +308,12 @@ user> (ds/rowvec-at stocks -1)
    (sample dataset 5 nil)))
 
 
+(defn print-all
+  "Helper function equivalent to `(tech.v3.dataset.print/print-range ... :all)`"
+  [dataset]
+  (vary-meta dataset clojure.core/assoc :print-index-range :all))
+
+
 (defn min-n-by-column
   "Find the minimum N entries (unsorted) by column.  Resulting data will be indexed in
   original order. If you want a sorted order then sort the result.

--- a/test/tech/v3/dataset_test.clj
+++ b/test/tech/v3/dataset_test.clj
@@ -13,6 +13,7 @@
             [tech.v3.dataset.test-utils :as test-utils]
             [tech.v3.dataset.rolling :as ds-roll]
             [tech.v3.dataset.column-filters :as cf]
+            [tech.v3.dataset.print :as ds-print]
             ;;Loading multimethods required to load the files
             [tech.v3.libs.poi]
             [tech.v3.libs.fastexcel]
@@ -1556,6 +1557,11 @@
           meta
           :k
           ))))
+
+(deftest print-all-test
+  (let [ds (ds/->dataset (for [i (range 1000)] {:a i}))]
+    (is (= (meta (ds/print-all ds))
+           (meta (ds-print/print-range ds :all))))))
 
 (comment
 


### PR DESCRIPTION
Not sure if this is a great idea, but it would save the effort of requiring `tech.v3.dataset.print` when repl'ing around.

I'm working with a lot of datasets with ~1000 rows in them at the moment and I often just want to print so I can text search them in the repl and such to make sure they have what I expect.

What do you think?