### PR TITLE
Run automated tests with different JDK versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,10 @@ on:
 
 jobs:
   test:
+    strategy:
+      fail-fast: false
+      matrix:
+        jdk-version: ["8", "11", "17"]
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
@@ -22,7 +26,7 @@ jobs:
       uses: actions/setup-java@v3
       with:
         distribution: 'temurin'
-        java-version: '8'
+        java-version: {{ matrix.jdk-version }}
     - name: Setup Clojure
       uses: DeLaGuardo/setup-clojure@12.1
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
       uses: actions/setup-java@v3
       with:
         distribution: 'temurin'
-        java-version: {{ matrix.jdk-version }}
+        java-version: ${{ matrix.jdk-version }}
     - name: Setup Clojure
       uses: DeLaGuardo/setup-clojure@12.1
       with:

--- a/deps.edn
+++ b/deps.edn
@@ -137,6 +137,9 @@
     }
    :extra-paths ["test"]}
 
+  :jdk-8 {}
+  :jdk-11
+  {:jvm-opts ["--add-opens=java.base/jdk.internal.ref=ALL-UNNAMED"]}
   :jdk-17
   {:jvm-opts ["--add-modules" "jdk.incubator.foreign,jdk.incubator.vector"
               "--enable-native-access=ALL-UNNAMED"

--- a/scripts/compile
+++ b/scripts/compile
@@ -1,4 +1,8 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+set -eu
+
+jdk_profile="${1:-jdk-8}"
 
 rm -rf target/classes
-clojure -T:build compile
+clojure -T:"${jdk_profile}":build compile

--- a/scripts/run-tests
+++ b/scripts/run-tests
@@ -1,5 +1,22 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-scripts/compile
+set -eu
+
+java_version=$(java -version 2>&1 | awk '/version/ {print $3}')
+jdk_profile=""
+
+case "${java_version}" in
+    \"1.8*)
+	jdk_profile="jdk-8"
+	;;
+    \"11*)
+	jdk_profile="jdk-11"
+	;;
+    \"17*)
+	jdk_profile="jdk-17"
+	;;
+esac
+
+scripts/compile "${jdk_profile}"
 clojure -X:dev:codegen
-clojure -M:dev:test --dir test --dir neanderthal
+clojure -M:dev:"${jdk_profile}":test --dir test --dir neanderthal


### PR DESCRIPTION
Follow up on previous work. Ability to run the tests with different JDK versions (8,11,17). Not sure if different JDK distribution is something the project needs/wants.

I looked at different OS/architecture (e.g. macOS/m1) but it seems that requires _"larger runners"_, only available for Teams and Enterprise customers.

https://github.blog/2023-10-02-introducing-the-new-apple-silicon-powered-m1-macos-larger-runner-for-github-actions/ 
