### PR TITLE
Bump fastexcel version and expose 'stableId'

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -68,7 +68,7 @@
     org.apache.poi/poi-ooxml {:mvn/version "5.2.3"
                               :exclusions [commons-codec/commons-codec]}
     com.univocity/univocity-parsers {:mvn/version "2.9.0"}
-    org.dhatim/fastexcel-reader {:mvn/version "0.12.8"
+    org.dhatim/fastexcel-reader {:mvn/version "0.16.0"
                                  :exclusions [org.apache.poi/poi-ooxml]}
     com.github.haifengl/smile-core {:mvn/version "2.6.0"
                                     :exclusions [org.slf4j/slf4j-api]}

--- a/java/tech/v3/dataset/Spreadsheet.java
+++ b/java/tech/v3/dataset/Spreadsheet.java
@@ -12,6 +12,10 @@ public class Spreadsheet
   public interface Sheet extends Iterable
   {
     public String name();
+
+    public String id();
+
+    public String stableId();
   }
   public interface Row extends Iterable
   {

--- a/src/tech/v3/libs/fastexcel.clj
+++ b/src/tech/v3/libs/fastexcel.clj
@@ -107,6 +107,8 @@
   (reify
     Spreadsheet$Sheet
     (name [this] (.getName sheet))
+    (id [this] (.getId sheet))
+    (stableId [this] (.getStableId sheet))
     (iterator [this]
       (let [iter (.iterator (.openStream sheet))]
         (reify java.util.Iterator


### PR DESCRIPTION
Expose the newly added `stableId` on the spreadsheet. See https://github.com/dhatim/fastexcel/pull/347 for more details.

When working with spreadsheets programmatically, it's nice to be able to rely on a stable sheet id that will not change regardless of user input, ie. sheet re-arrangment, deletion etc.