### PR TITLE
`[select]` working with a Clojure vector of bools

### DIFF
--- a/src/tech/v3/dataset/impl/column.clj
+++ b/src/tech/v3/dataset/impl/column.clj
@@ -195,7 +195,7 @@
        (cond
          (nil? selection) (hamf/range 0)
          ;;Cannot possibly be negative
-         (= (dtype/elemwise-datatype selection) :boolean)
+         (and (sequential? selection) (boolean? (first selection)))
          (un-pred/bool-reader->indexes (dtype/ensure-reader selection))
          (set/bitset? selection)
          (set/->integer-random-access selection)

--- a/test/tech/v3/dataset_test.clj
+++ b/test/tech/v3/dataset_test.clj
@@ -1722,6 +1722,16 @@
 
     (is (= 3 (count (get data (int 0)))))))
 
+(deftest select-bool-issue-387
+  (let [ds (ds/->dataset {:a (range 10)})
+        vec-of-bools [true false true false true false true false true false]
+        expected [0 2 4 6 8]]
+    (is (= expected
+           (-> (ds/select ds :all (dtype/make-list :boolean vec-of-bools))
+               :a)))
+    (is (= expected
+           (-> (ds/select ds :all vec-of-bools)
+               :a)))))
 
 (comment
   (require '[criterium.core :as crit])


### PR DESCRIPTION
 - tests pass
 - confusing things are now possible: `(ds/select ds :all [true :true :false nil :nil 17])`
 - Fixes: #387