### PR TITLE
Use charred instead of cheshire for Tribuo JSON

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ java_test/test.arrow
 java_test/simulation*
 .idea
 .calva
+*.iml

--- a/src/tech/v3/libs/tribuo.clj
+++ b/src/tech/v3/libs/tribuo.clj
@@ -41,7 +41,7 @@ _unnamed [5 1]:
             [tech.v3.datatype :as dtype]
             [tech.v3.datatype.casting :as casting]
             [clojure.set :as set]
-            [cheshire.core :as json])
+            [charred.api :as charred])
   (:import [tech.v3.datatype Buffer ArrayHelpers]
            [java.util HashMap Map List]
            [java.nio.file Files]
@@ -321,6 +321,6 @@ _unnamed [5 1]:
   [config-components trainer-name]
   (let [config {:config {:components config-components}}
         tmp (.toString (Files/createTempFile "config" ".json" (make-array FileAttribute 0)))
-        _ (->> config json/generate-string (spit tmp))
+        _ (charred/write-json tmp config)
         config-manager (ConfigurationManager. tmp)]
     (.lookup config-manager trainer-name)))


### PR DESCRIPTION
I was experimenting with this library + Tribuo, ran into an issue, and realized that this library was using Cheshire instead of Charred. This was odd since Cheshire was not a direct dependency of this library, but Charred was present.

Fixes #442