### PR TITLE
[column-parsers] Add `:disable-na-as-missing?` for fixed types too.

### DIFF
--- a/src/tech/v3/dataset/io/column_parsers.clj
+++ b/src/tech/v3/dataset/io/column_parsers.clj
@@ -197,7 +197,8 @@
                           ^IMutList failed-values
                           ^RoaringBitmap failed-indexes
                           column-name
-                          ^:unsynchronized-mutable ^long max-idx]
+                          ^:unsynchronized-mutable ^long max-idx
+                          disable-na-as-missing?]
   dtype-proto/PECount
   (ecount [_this] (inc max-idx))
   Indexed
@@ -216,7 +217,7 @@
       ;;be in the space of the container or it could require the parse-fn
       ;;to make it.
       (let [parsed-value (cond
-                           (missing-value? value false)
+                           (missing-value? value disable-na-as-missing?)
                            :tech.v3.dataset/missing
                            (and (identical? (dtype/datatype value) container-dtype)
                                 (not (instance? String value)))
@@ -299,19 +300,17 @@
         missing (bitmap/->bitmap)]
     (FixedTypeParser. container dtype missing-value parse-fn
                       missing failed-values failed-indexes
-                      cname -1)))
-
+                      cname -1
+                      (get options :disable-na-as-missing?))))
 
 (defn parser-kwd-list->parser-tuples
   [kwd-list]
   (mapv parser-entry->parser-tuple kwd-list))
 
-
 (def default-parser-datatype-sequence
   [:bool :int16 :int32 :int64 :float64 :uuid
    :packed-duration :packed-local-date
    :zoned-date-time :string :text :boolean])
-
 
 (defn- promote-container
   ^IMutList [old-container ^RoaringBitmap missing new-dtype options]

--- a/test/tech/v3/dataset_test.clj
+++ b/test/tech/v3/dataset_test.clj
@@ -1756,6 +1756,12 @@
     (is (= expected-column (:a ds1)))
     (is (= expected-column (:a ds2)))))
 
+(deftest fixed-type-disable-na-as-missing
+  (let [data [{:a "no"} {:a "NA"} {:a "na"}]
+        ds1 (ds/->dataset data {:parser-fn :string :disable-na-as-missing? true})
+        ds2 (ds/->dataset data {:parser-fn :string :disable-na-as-missing? false})]
+    (is (= ["no" "NA" "na"] (:a ds1)))
+    (is (= ["no" nil nil] (:a ds2)))))
 
 (deftest sub-buffer-col-incorrect-missing
   (let [ds (-> (ds/->dataset {:a (range 20)})


### PR DESCRIPTION
Similar to https://github.com/techascent/tech.ml.dataset/pull/399, added the option for `:disable-na-as-missing?` for `FixedTypeParser`.

Addresses https://github.com/techascent/tech.ml.dataset/issues/460